### PR TITLE
Moved $25,000 requirement check from the verify cronjob to each time a rebalance occurs.

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -131,9 +131,6 @@ class Bot extends EventEmitter {
         //error if account is not a margin account
         if(!['reg_t', 'portfolio'].includes(brokerDetails.margin_type)) throw {type: 'error', message: 'Broker must be a RegT or Portfolio margin account.'};
         
-        //error if account is less than 25k
-        if(math.evaluate('a < 25000', {a: brokerDetails.value})) throw {type: 'error', message: 'Account must maintain a minimum balance of $25,000.'};
-        
         //error if broker buying power is negative
         if(math.evaluate('a < 0', {a: brokerDetails.buying_power})) throw {type: 'error', message: 'Broker buying power can not be negative.'};
         
@@ -466,6 +463,15 @@ class Bot extends EventEmitter {
   async rebalance() {
     //error if closing or scheduled close
     if(this.status.closing || this.status.scheduled_close) throw new Error('Can not rebalance when closing or scheduled closing.');
+    //error and close all positions if account is less than 25k
+    let brokerDetails = await this.Broker.getAccountDetails();
+    if(math.evaluate('a < 25000', {a: brokerDetails.value})) {
+      // emit error
+      this.emit('error', {info: {type: 'rebalance'}, message: 'Account must maintain a minimum balance of $25,000.'});
+      // stop bot
+      await this.stop();
+      return;
+    }
     
     //skip and set repeatRebalance if rebalancing
     if(this.status.rebalancing) {


### PR DESCRIPTION
- The bot will stop when a rebalance occurs and the user is below the $25,000 threshold.